### PR TITLE
Downgrade llvm to version 18 in build workflow for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,10 +86,12 @@ jobs:
             cmake \
             coreutils \
             boost \
-            llvm \
+            llvm@18 \
             sdl2 \
             sdl2_image \
             nasm
+      - name: Configure environment (macOS)
+        run: echo "PATH=$(brew --prefix llvm@18)/bin:$PATH" >> $GITHUB_ENV            
       - name: Precompile nxdk
         run: |
           echo "Precompiling nxdk to allow CMake to run correctly."


### PR DESCRIPTION
Updated llvm installation to version 18 and configured environment path.